### PR TITLE
Remove length check from unix::crypt to match crypt(3) behavior

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,11 +339,7 @@ pub mod unix {
 		"6" => sha512_crypt::hash_with(hash, pass),
 		_ => return Err(Error::InvalidHashString)
 	    },
-	    _ => if hash.len() == 13 {
-		unix_crypt::hash_with(hash, pass)
-	    } else {
-		return Err(Error::InvalidHashString)
-	    }
+	    _ => unix_crypt::hash_with(hash, pass)
 	}
     }
 
@@ -359,12 +355,6 @@ pub mod unix {
 	    assert_eq!(super::crypt("password", "$1$5pZSV9va$azfrPr6af3Fc7dLblQXVa0").unwrap(),
 		"$1$5pZSV9va$azfrPr6af3Fc7dLblQXVa0");
 	    assert_eq!(super::crypt("test", "aZGJuE6EXrjEE").unwrap(), "aZGJuE6EXrjEE");
-	}
-
-	#[test]
-	#[should_panic(expected="value: InvalidHashString")]
-	fn crypt_unrecognized() {
-	    let _ = super::crypt("test", "RZA/GZA").unwrap();
 	}
     }
 }


### PR DESCRIPTION
The documentation for `unix::crypt` describes it as a "Unix **crypt**(3) work-alike." However, when `unix::crypt` falls back to the DES option based on the salt, it returns an error if the argument is not 13 characters. This does not match the behavior of `crypt(3)`, which allows any salt length. For example, this C snippet compiles and runs without error using GCC 5.4.0 on Ubuntu 16.04:

```c
#include <assert.h>
#define _GNU_SOURCE
#include <crypt.h>
#include <stdlib.h>

int main()
{
	assert(crypt("foo", "bar") != NULL);
	return 0;
}
```

This PR removes the length check from `unix::crypt` and removes a test with a salt that is not 13 characters that expects an error.