### PR TITLE
Update dependencies, update edition

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'pwhash'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=pwhash"
+                ],
+                "filter": {
+                    "name": "pwhash",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 keywords = ["password", "hash", "hashing", "crypt"]
 categories = ["cryptography", "authentication"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 md-5 = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 md-5 = "0.10.1"
 sha-1 = "0.9"
 sha2 = "0.9"
-blowfish = { version = "0.7", features = ["bcrypt"] }
+blowfish = { version = "0.8.0", features = ["bcrypt"] }
 hmac = "0.10"
 byteorder = "1"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "authentication"]
 edition = "2018"
 
 [dependencies]
-md-5 = "0.9"
+md-5 = "0.10.1"
 sha-1 = "0.9"
 sha2 = "0.9"
 blowfish = { version = "0.7", features = ["bcrypt"] }


### PR DESCRIPTION
This doesn't update all dependencies, and some are only partially updated. This is the most I could update without needing code-changes (and thus the most I felt comfortable doing without risking potential API issues). I think a future idea would be to break unix_crypt into a separate file, and then make it and the various hashing algorithms features (so you could for example say "I only need to verify md5crypt hashes, so don't include stuff like blowfish and rand").